### PR TITLE
fix: typo in production url

### DIFF
--- a/lib/ex_stone_openbank/config.ex
+++ b/lib/ex_stone_openbank/config.ex
@@ -71,7 +71,7 @@ defmodule ExStoneOpenbank.Config do
     if sandbox?(name) do
       "https://sandbox-accounts.openbank.stone.com.br"
     else
-      "https://accounts.openbank.stone.com.br/"
+      "https://accounts.openbank.stone.com.br"
     end
   end
 


### PR DESCRIPTION
I started putting this in production and saw that there is a typo in production URL that a fixed in a previous PR https://github.com/victorolinasc/ex-stone-openbank/pull/4 (fixed but fixed wrongly).

I tested now and it is working in production.