### PR TITLE
fix: change authenticator config

### DIFF
--- a/lib/ex_stone_openbank/authenticator.ex
+++ b/lib/ex_stone_openbank/authenticator.ex
@@ -112,14 +112,13 @@ defmodule ExStoneOpenbank.Authenticator do
   Authenticates with Stone Openbank API using the given signer and client_id
   """
   @spec authenticate(name :: atom()) ::
-          {:ok, %{access_token: token :: String.t(), refresh_token: token :: String.t()}}
+          {:ok, %{access_token: token :: String.t()}}
           | {:error, reason :: atom()}
   def authenticate(name) do
     with opts <- Config.options(name),
          {:ok, token, _claims} <- generate_client_credentials_token(name, opts),
-         {:ok, %{"access_token" => access, "refresh_token" => refresh}} <-
-           do_login(name, opts, token) do
-      tokens = %{access_token: access, refresh_token: refresh}
+         {:ok, %{"access_token" => access}} <- do_login(name, opts, token) do
+      tokens = %{access_token: access}
       :ets.insert(name, {:tokens, tokens})
       {:ok, tokens}
     else

--- a/test/ex_stone_openbank/authenticator/http_middleware_test.exs
+++ b/test/ex_stone_openbank/authenticator/http_middleware_test.exs
@@ -29,11 +29,11 @@ defmodule ExStoneOpenbank.Authenticator.AuthHTTPMiddlewareTest do
           # To know if this is the first time we check if already have tokens
           case Authenticator.access_token(ctx.opts[:name]) do
             {:ok, "token"} ->
-              response = json_response(%{access_token: "new_token", refresh_token: "new_refresh"})
+              response = json_response(%{access_token: "new_token"})
               assert_authentication(ctx.opts[:client_id], response, env)
 
             {:error, :unauthenticated} ->
-              response = json_response(%{access_token: "token", refresh_token: "refresh"})
+              response = json_response(%{access_token: "token"})
               assert_authentication(ctx.opts[:client_id], response, env)
           end
 

--- a/test/ex_stone_openbank/authenticator_test.exs
+++ b/test/ex_stone_openbank/authenticator_test.exs
@@ -11,8 +11,7 @@ defmodule ExStoneOpenbank.AuthenticatorTest do
     test "tries authentication upon start", ctx do
       # started on setup block
       assert Authenticator.tokens(ctx.opts[:name]) == %{
-               access_token: "token",
-               refresh_token: "refresh_token"
+               access_token: "token"
              }
     end
   end
@@ -20,8 +19,7 @@ defmodule ExStoneOpenbank.AuthenticatorTest do
   describe "handle_call/3 - :refresh_token" do
     test "do not re-authenticate if it did not pass time skew", ctx do
       assert Authenticator.refresh_token(ctx.opts[:name]) == %{
-               access_token: "token",
-               refresh_token: "refresh_token"
+               access_token: "token"
              }
     end
 
@@ -30,12 +28,11 @@ defmodule ExStoneOpenbank.AuthenticatorTest do
 
       expect_authentication(
         ctx.opts[:client_id],
-        json_response(%{access_token: "new_token", refresh_token: "new_refresh_token"})
+        json_response(%{access_token: "new_token"})
       )
 
       assert Authenticator.refresh_token(ctx.opts[:name]) == %{
-               access_token: "new_token",
-               refresh_token: "new_refresh_token"
+               access_token: "new_token"
              }
     end
   end

--- a/test/support/tesla_helper.ex
+++ b/test/support/tesla_helper.ex
@@ -71,6 +71,6 @@ defmodule ExStoneOpenbank.TeslaHelper do
 
     if response,
       do: response,
-      else: json_response(%{access_token: "token", refresh_token: "refresh_token"})
+      else: json_response(%{access_token: "token"})
   end
 end


### PR DESCRIPTION
Since some of the latest releases, Stone made it mandatory to send the `iss` claim using the same value from `client_id`.

Also, during my tests, I just realized that the API isn't returning the `refresh_token` anymore. Since the library isn't using it, I just removed. Another problem was that the `with` clause to do the login was returning even with the breaking match for `refresh_token` because it didn't have an `else` clause. Now any unexpected value in this `with` will throw an error.