### PR TITLE
feat: pix payment action

### DIFF
--- a/lib/ex_stone_openbank/api/models/pix_payment/confirmation_input.ex
+++ b/lib/ex_stone_openbank/api/models/pix_payment/confirmation_input.ex
@@ -1,0 +1,20 @@
+defmodule ExStoneOpenbank.API.Model.PixPayment.ConfirmationInput do
+  @moduledoc false
+
+  use ExStoneOpenbank.Model
+
+  @fields [:id, :idempotency_key]
+  @optional []
+
+  embedded_schema do
+    field :id
+    field :idempotency_key
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> validate_required(@fields)
+  end
+end

--- a/lib/ex_stone_openbank/api/models/pix_payment/creation_input.ex
+++ b/lib/ex_stone_openbank/api/models/pix_payment/creation_input.ex
@@ -1,0 +1,42 @@
+defmodule ExStoneOpenbank.API.Model.PixPayment.CreationInput do
+  @moduledoc false
+
+  use ExStoneOpenbank.Model
+
+  alias ExStoneOpenbank.API.Model.PixPayment.CreationInput.Target
+
+  @fields [:account_id, :amount, :idempotency_key]
+  @optional [:description, :key]
+
+  embedded_schema do
+    field :account_id
+    field :amount, :integer
+    field :description
+    field :key
+    field :idempotency_key
+
+    embeds_one :target, Target
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> cast_embed(:target)
+    |> validate_required(@fields)
+    |> validate_target_presence()
+  end
+
+  defp validate_target_presence(%Ecto.Changeset{valid?: true} = changeset) do
+    key = get_change(changeset, :key)
+    target = get_change(changeset, :target)
+
+    if is_nil(key) and is_nil(target) do
+      add_error(changeset, :target, ":target or :key must be set")
+    else
+      changeset
+    end
+  end
+
+  defp validate_target_presence(changeset), do: changeset
+end

--- a/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target.ex
+++ b/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target.ex
@@ -1,0 +1,22 @@
+defmodule ExStoneOpenbank.API.Model.PixPayment.CreationInput.Target do
+  @moduledoc false
+
+  use ExStoneOpenbank.Model
+
+  alias ExStoneOpenbank.API.Model.PixPayment.CreationInput.Target.{Account, Entity, Institution}
+
+  embedded_schema do
+    embeds_one :account, Account
+    embeds_one :entity, Entity
+    embeds_one :institution, Institution
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, [])
+    |> cast_embed(:account, required: true)
+    |> cast_embed(:entity)
+    |> cast_embed(:institution, required: true)
+  end
+end

--- a/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target/account.ex
+++ b/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target/account.ex
@@ -1,0 +1,22 @@
+defmodule ExStoneOpenbank.API.Model.PixPayment.CreationInput.Target.Account do
+  @moduledoc """
+  Account model
+  """
+  use ExStoneOpenbank.Model
+
+  @fields [:account_code]
+  @optional [:branch_code, :account_type]
+
+  embedded_schema do
+    field :account_code
+    field :branch_code
+    field :account_type
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> validate_required(@fields)
+  end
+end

--- a/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target/entity.ex
+++ b/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target/entity.ex
@@ -1,0 +1,21 @@
+defmodule ExStoneOpenbank.API.Model.PixPayment.CreationInput.Target.Entity do
+  @moduledoc """
+  Account model
+  """
+  use ExStoneOpenbank.Model
+
+  @fields [:name, :document]
+  @optional []
+
+  embedded_schema do
+    field :name
+    field :document
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> validate_required(@fields)
+  end
+end

--- a/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target/institution.ex
+++ b/lib/ex_stone_openbank/api/models/pix_payment/creation_input/target/institution.ex
@@ -1,0 +1,19 @@
+defmodule ExStoneOpenbank.API.Model.PixPayment.CreationInput.Target.Institution do
+  @moduledoc false
+
+  use ExStoneOpenbank.Model
+
+  @fields []
+  @optional [:ispb]
+
+  embedded_schema do
+    field :ispb
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> validate_required(@fields)
+  end
+end

--- a/lib/ex_stone_openbank/api/models/pix_payment/creation_response.ex
+++ b/lib/ex_stone_openbank/api/models/pix_payment/creation_response.ex
@@ -1,0 +1,23 @@
+defmodule ExStoneOpenbank.API.Model.PixPayment.CreationResponse do
+  @moduledoc false
+
+  use ExStoneOpenbank.Model
+
+  @fields [:id, :end_to_end_id, :fee, :fee_metadata, :status]
+  @optional []
+
+  embedded_schema do
+    field :id, Ecto.UUID
+    field :end_to_end_id
+    field :fee, :integer
+    field :fee_metadata, :map
+    field :status
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> validate_required(@fields)
+  end
+end

--- a/lib/ex_stone_openbank/api/models/pix_resources/dynamic_invoice_input.ex
+++ b/lib/ex_stone_openbank/api/models/pix_resources/dynamic_invoice_input.ex
@@ -1,0 +1,24 @@
+defmodule ExStoneOpenbank.API.Model.PixResources.DynamicInvoiceInput do
+  @moduledoc false
+
+  use ExStoneOpenbank.Model
+
+  @fields [:account_id, :amount, :key, :transaction_id, :idempotency_key]
+  @optional [:request_for_payer]
+
+  embedded_schema do
+    field :account_id
+    field :amount, :integer
+    field :key
+    field :transaction_id
+    field :request_for_payer
+    field :idempotency_key
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> validate_required(@fields)
+  end
+end

--- a/lib/ex_stone_openbank/api/models/pix_resources/dynamic_invoice_response.ex
+++ b/lib/ex_stone_openbank/api/models/pix_resources/dynamic_invoice_response.ex
@@ -1,0 +1,22 @@
+defmodule ExStoneOpenbank.API.Model.PixResources.DynamicInvoiceResponse do
+  @moduledoc false
+
+  use ExStoneOpenbank.Model
+
+  @fields [:id, :transaction_id, :qr_code_content, :qr_code_image]
+  @optional []
+
+  embedded_schema do
+    field :id
+    field :transaction_id
+    field :qr_code_content
+    field :qr_code_image
+  end
+
+  @doc false
+  def changeset(model \\ %__MODULE__{}, params) do
+    model
+    |> cast(params, @fields ++ @optional)
+    |> validate_required(@fields)
+  end
+end

--- a/lib/ex_stone_openbank/api/pix_payment.ex
+++ b/lib/ex_stone_openbank/api/pix_payment.ex
@@ -1,8 +1,8 @@
 defmodule ExStoneOpenbank.API.PixPayment do
-  @moduledoc """
-  """
-  alias ExStoneOpenbank.API.Model.PixPayment.{CreationInput, CreationResponse, ConfirmationInput}
+  @moduledoc false
+
   alias ExStoneOpenbank.{HTTP, Model}
+  alias ExStoneOpenbank.API.Model.PixPayment.{ConfirmationInput, CreationInput, CreationResponse}
 
   @base_url "/pix/outbound_pix_payments"
 

--- a/lib/ex_stone_openbank/api/pix_payment.ex
+++ b/lib/ex_stone_openbank/api/pix_payment.ex
@@ -1,0 +1,26 @@
+defmodule ExStoneOpenbank.API.PixPayment do
+  @moduledoc """
+  """
+  alias ExStoneOpenbank.API.Model.PixPayment.{CreationInput, CreationResponse}
+  alias ExStoneOpenbank.{HTTP, Model}
+
+  @base_url "/pix/outbound_pix_payments"
+
+  def create(config_name, input) do
+    case CreationInput.cast_and_apply(input) do
+      %CreationInput{} = input ->
+        body = Model.to_map(input)
+
+        HTTP.post(
+          config_name,
+          @base_url,
+          body,
+          [headers: [{"x-stone-idempotency-key", input.idempotency_key}]],
+          model: CreationResponse
+        )
+
+      err ->
+        err
+    end
+  end
+end

--- a/lib/ex_stone_openbank/api/pix_payment.ex
+++ b/lib/ex_stone_openbank/api/pix_payment.ex
@@ -1,7 +1,7 @@
 defmodule ExStoneOpenbank.API.PixPayment do
   @moduledoc """
   """
-  alias ExStoneOpenbank.API.Model.PixPayment.{CreationInput, CreationResponse}
+  alias ExStoneOpenbank.API.Model.PixPayment.{CreationInput, CreationResponse, ConfirmationInput}
   alias ExStoneOpenbank.{HTTP, Model}
 
   @base_url "/pix/outbound_pix_payments"
@@ -17,6 +17,21 @@ defmodule ExStoneOpenbank.API.PixPayment do
           body,
           [headers: [{"x-stone-idempotency-key", input.idempotency_key}]],
           model: CreationResponse
+        )
+
+      err ->
+        err
+    end
+  end
+
+  def confirm(config_name, input) do
+    case ConfirmationInput.cast_and_apply(input) do
+      %ConfirmationInput{} = input ->
+        HTTP.post(
+          config_name,
+          "#{@base_url}/#{input.id}/actions/confirm",
+          "",
+          headers: [{"x-stone-idempotency-key", input.idempotency_key}]
         )
 
       err ->

--- a/lib/ex_stone_openbank/api/pix_payment.ex
+++ b/lib/ex_stone_openbank/api/pix_payment.ex
@@ -1,11 +1,46 @@
 defmodule ExStoneOpenbank.API.PixPayment do
-  @moduledoc false
+  @moduledoc """
+  Interacts with Pix payments API for sending money to another entity as seen
+  in the documentation: https://docs.openbank.stone.com.br/docs/referencia-da-api/pix/pagamento/
+  """
 
   alias ExStoneOpenbank.{HTTP, Model}
   alias ExStoneOpenbank.API.Model.PixPayment.{ConfirmationInput, CreationInput, CreationResponse}
 
   @base_url "/pix/outbound_pix_payments"
 
+  @doc """
+  Calls the API to create a new transaction, providing the target information, amount and extra details.
+
+  It can be done using complete target information (bank code, branch code, account code and document)
+  or by using a Pix key.
+
+  Documentation: https://docs.openbank.stone.com.br/docs/referencia-da-api/pix/pagamento/criar-pagamento-pendente/
+
+  A created transaction must be confirmed using confirm/2.
+
+  ### Examples
+
+    {:ok, %CreationResponse{id: pix_id, end_to_end_id: e2e_id}} =
+      ExStoneOpenbank.API.PixPayment.create(:my_application_name, %{
+        account_id: "<<account uuid>>",
+        amount: 199,
+        idempotency_key: "<<key>>",
+        key: "your.key.that.can.be.an.email@stone.com.br"
+      })
+
+    {:ok, _} =
+      ExStoneOpenbank.API.PixPayment.create(:my_application_name, %{
+        account_id: "<<account uuid>>",
+        amount: 199,
+        idempotency_key: "<<key>>",
+        target: %{
+          institution: %{ispb: "???"},
+          account: %{account_code: "???", account_type: "PG"},
+          entity: %{name: "???", document: "???"}
+        }
+      })
+  """
   def create(config_name, input) do
     case CreationInput.cast_and_apply(input) do
       %CreationInput{} = input ->
@@ -24,6 +59,20 @@ defmodule ExStoneOpenbank.API.PixPayment do
     end
   end
 
+  @doc """
+  After a Pix transaction is successfully created using create/2, a id
+  is returned as response and it must be used to call confirm.
+
+  Documentation: https://docs.openbank.stone.com.br/docs/referencia-da-api/pix/pagamento/confirmar-pagamento-pendente/
+
+  ### Examples
+
+    {:ok, _} =
+      ExStoneOpenbank.API.PixPayment.confirm(:my_application_name, %{
+        id: pix_id,
+        idempotency_key: "<<key>>"
+      })
+  """
   def confirm(config_name, input) do
     case ConfirmationInput.cast_and_apply(input) do
       %ConfirmationInput{} = input ->

--- a/lib/ex_stone_openbank/api/pix_payment.ex
+++ b/lib/ex_stone_openbank/api/pix_payment.ex
@@ -41,6 +41,8 @@ defmodule ExStoneOpenbank.API.PixPayment do
         }
       })
   """
+  @spec create(config_name :: atom(), input :: map()) ::
+          {:ok, CreationResponse.t()} | {:error, atom()}
   def create(config_name, input) do
     case CreationInput.cast_and_apply(input) do
       %CreationInput{} = input ->
@@ -73,6 +75,8 @@ defmodule ExStoneOpenbank.API.PixPayment do
         idempotency_key: "<<key>>"
       })
   """
+  @spec confirm(config_name :: atom(), input :: map()) ::
+          {:ok, any()} | {:error, atom()}
   def confirm(config_name, input) do
     case ConfirmationInput.cast_and_apply(input) do
       %ConfirmationInput{} = input ->

--- a/lib/ex_stone_openbank/api/pix_resources.ex
+++ b/lib/ex_stone_openbank/api/pix_resources.ex
@@ -1,0 +1,44 @@
+defmodule ExStoneOpenbank.API.PixResources do
+  @moduledoc """
+  Defines methods for handling pix resources such as key handling
+  and invoice generation.
+  """
+
+  alias ExStoneOpenbank.{HTTP, Model}
+  alias ExStoneOpenbank.API.Model.PixResources.{DynamicInvoiceInput, DynamicInvoiceResponse}
+
+  @base_url "/pix_payment_invoices"
+
+  @doc """
+  Generates an invoice and its QR code according to the documentation:
+  https://docs.openbank.stone.com.br/docs/referencia-da-api/pix/recebimento/criar-qrcode-dinamico/
+
+  ### Examples
+
+    {:ok, %{qr_code_content: content_for_copy_and_paste, qr_code_image: b64_encoded_image}} =
+      ExStoneOpenbank.API.PixResources.dynamic_invoice(:my_application_name, %{
+        account_id: "<<account uuid>>",
+        amount: 1,
+        key: "your.key.that.can.be.an.email@stone.com.br",
+        transaction_id: <<generated transaction id>>,
+        idempotency_key: "<<key>>"
+      })
+  """
+  def dynamic_invoice(config_name, input) do
+    case DynamicInvoiceInput.cast_and_apply(input) do
+      %DynamicInvoiceInput{} = input ->
+        body = Model.to_map(input)
+
+        HTTP.post(
+          config_name,
+          @base_url,
+          body,
+          [headers: [{"x-stone-idempotency-key", input.idempotency_key}]],
+          model: DynamicInvoiceResponse
+        )
+
+      err ->
+        err
+    end
+  end
+end

--- a/lib/ex_stone_openbank/api/pix_resources.ex
+++ b/lib/ex_stone_openbank/api/pix_resources.ex
@@ -24,6 +24,8 @@ defmodule ExStoneOpenbank.API.PixResources do
         idempotency_key: "<<key>>"
       })
   """
+  @spec dynamic_invoice(config_name :: atom(), input :: map()) ::
+          {:ok, DynamicInvoiceResponse.t()} | {:error, atom()}
   def dynamic_invoice(config_name, input) do
     case DynamicInvoiceInput.cast_and_apply(input) do
       %DynamicInvoiceInput{} = input ->

--- a/lib/ex_stone_openbank/http.ex
+++ b/lib/ex_stone_openbank/http.ex
@@ -23,7 +23,7 @@ defmodule ExStoneOpenbank.HTTP do
           | :unexpected_return
 
   @typep body ::
-           %{required(String.t()) => body()} | list(body()) | number() | boolean() | String.t()
+           %{required(String.t()) => body()} | list(body()) | number() | boolean() | String.t() | struct()
   @typep parsed_return :: {:ok, body} | {:error, error_reason}
 
   defguardp is_client_error(status) when is_integer(status) and status >= 400 and status < 500

--- a/lib/ex_stone_openbank/http.ex
+++ b/lib/ex_stone_openbank/http.ex
@@ -23,7 +23,13 @@ defmodule ExStoneOpenbank.HTTP do
           | :unexpected_return
 
   @typep body ::
-           %{required(String.t()) => body()} | list(body()) | number() | boolean() | String.t() | struct()
+           %{required(String.t()) => body()}
+           | list(body())
+           | number()
+           | boolean()
+           | String.t()
+           | map()
+           | struct()
   @typep parsed_return :: {:ok, body} | {:error, error_reason}
 
   defguardp is_client_error(status) when is_integer(status) and status >= 400 and status < 500


### PR DESCRIPTION
Currently this library supports sending TED transfers and paying barcodes. 

This PR introduces base features for Pix payments (https://docs.openbank.stone.com.br/docs/referencia-da-api/pix/pagamento/), making it possible to create and confirm a transaction either using a key or complete target information.